### PR TITLE
Focus preview list on page 20

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryPreviewsScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryPreviewsScene.java
@@ -58,6 +58,7 @@ import com.hippo.widget.recyclerview.AutoGridLayoutManager;
 import com.hippo.lib.yorozuya.AssertUtils;
 import com.hippo.lib.yorozuya.LayoutUtils;
 import com.hippo.lib.yorozuya.ViewUtils;
+import com.hippo.easyrecyclerview.LayoutManagerUtils;
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.greenrobot.eventbus.EventBus;
@@ -398,7 +399,8 @@ public class GalleryPreviewsScene extends ToolbarScene implements EasyRecyclerVi
                 for (int i = 0, n = data.size(); i < n; i++) {
                     if (data.get(i).getPosition() == mInitialPage) {
                         if (mRecyclerView != null) {
-                            mRecyclerView.scrollToPosition(i);
+                            LayoutManagerUtils.scrollToPositionWithOffset(
+                                    mRecyclerView.getLayoutManager(), i, 0);
                             mDidInitialScroll = true;
                         }
                         break;

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryPreviewsScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryPreviewsScene.java
@@ -36,6 +36,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.hippo.easyrecyclerview.EasyRecyclerView;
+import com.hippo.easyrecyclerview.LayoutManagerUtils;
 import com.hippo.easyrecyclerview.MarginItemDecoration;
 import com.hippo.ehviewer.EhApplication;
 import com.hippo.ehviewer.R;
@@ -58,7 +59,6 @@ import com.hippo.widget.recyclerview.AutoGridLayoutManager;
 import com.hippo.lib.yorozuya.AssertUtils;
 import com.hippo.lib.yorozuya.LayoutUtils;
 import com.hippo.lib.yorozuya.ViewUtils;
-import com.hippo.easyrecyclerview.LayoutManagerUtils;
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.greenrobot.eventbus.EventBus;

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryPreviewsScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryPreviewsScene.java
@@ -63,11 +63,14 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import org.greenrobot.eventbus.EventBus;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 public class GalleryPreviewsScene extends ToolbarScene implements EasyRecyclerView.OnItemClickListener {
 
     public static final String KEY_GALLERY_INFO = "gallery_info";
+    /** Start page scroll target */
+    public static final String KEY_INITIAL_PAGE = "initial_page";
     private final static String KEY_HAS_FIRST_REFRESH = "has_first_refresh";
 
     /*---------------
@@ -89,6 +92,8 @@ public class GalleryPreviewsScene extends ToolbarScene implements EasyRecyclerVi
     private GalleryPreviewHelper mHelper;
 
     private boolean mHasFirstRefresh = false;
+    private int mInitialPage = -1;
+    private boolean mDidInitialScroll = false;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -112,6 +117,7 @@ public class GalleryPreviewsScene extends ToolbarScene implements EasyRecyclerVi
         }
 
         mGalleryInfo = args.getParcelable(KEY_GALLERY_INFO);
+        mInitialPage = args.getInt(KEY_INITIAL_PAGE, -1);
     }
 
     private void onRestore(@NonNull Bundle savedInstanceState) {
@@ -386,6 +392,19 @@ public class GalleryPreviewsScene extends ToolbarScene implements EasyRecyclerVi
             }
 
             mHelper.onGetPageData(taskId, result.second, 0, list);
+
+            if (!mDidInitialScroll && mInitialPage >= 0) {
+                List<GalleryPreview> data = mHelper.getData();
+                for (int i = 0, n = data.size(); i < n; i++) {
+                    if (data.get(i).getPosition() == mInitialPage) {
+                        if (mRecyclerView != null) {
+                            mRecyclerView.scrollToPosition(i);
+                            mDidInitialScroll = true;
+                        }
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
@@ -1527,6 +1527,9 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
             if (null != mGalleryDetail) {
                 Bundle args = new Bundle();
                 args.putParcelable(GalleryPreviewsScene.KEY_GALLERY_INFO, mGalleryDetail);
+                if (mGalleryDetail.pages > 20) {
+                    args.putInt(GalleryPreviewsScene.KEY_INITIAL_PAGE, 19);
+                }
                 startScene(new Announcer(GalleryPreviewsScene.class).setArgs(args));
             }
         } else if (mTitle == v) {

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/gallery/detail/GalleryDetailScene.java
@@ -1528,7 +1528,9 @@ public class GalleryDetailScene extends BaseScene implements View.OnClickListene
                 Bundle args = new Bundle();
                 args.putParcelable(GalleryPreviewsScene.KEY_GALLERY_INFO, mGalleryDetail);
                 if (mGalleryDetail.pages > 20) {
-                    args.putInt(GalleryPreviewsScene.KEY_INITIAL_PAGE, 19);
+                    // Skip the first 20 thumbnails already displayed on the
+                    // gallery info page and start from page 21
+                    args.putInt(GalleryPreviewsScene.KEY_INITIAL_PAGE, 20);
                 }
                 startScene(new Announcer(GalleryPreviewsScene.class).setArgs(args));
             }


### PR DESCRIPTION
## Summary
- allow GalleryPreviewsScene to scroll to a specific page
- when a gallery has more than 20 pages, open previews focused on page 20

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b23927fbc832b972244c5145a3d91